### PR TITLE
Support VK_NV_device_generated_commands in addition to the old NVX variant

### DIFF
--- a/thsvs_simpler_vulkan_synchronization.h
+++ b/thsvs_simpler_vulkan_synchronization.h
@@ -182,10 +182,8 @@ typedef enum ThsvsAccessType {
     THSVS_ACCESS_NONE,                                                      // No access. Useful primarily for initialization
 
 // Read access
-#if defined(VK_NV_device_generated_commands) || defined(VK_NVX_device_generated_commands)
     // Requires VK_NV_device_generated_commands to be enabled
     THSVS_ACCESS_COMMAND_BUFFER_READ_NV,                                    // Command buffer read operation as defined by NV_device_generated_commands
-#endif
     THSVS_ACCESS_INDIRECT_BUFFER,                                           // Read as an indirect buffer for drawing or dispatch
     THSVS_ACCESS_INDEX_BUFFER,                                              // Read as an index buffer for drawing
     THSVS_ACCESS_VERTEX_BUFFER,                                             // Read as a vertex buffer for drawing
@@ -242,10 +240,8 @@ typedef enum ThsvsAccessType {
     THSVS_END_OF_READ_ACCESS,
 
 // Write access
-#if defined(VK_NV_device_generated_commands) || defined(VK_NVX_device_generated_commands)
     // Requires VK_NV_device_generated_commands to be enabled
     THSVS_ACCESS_COMMAND_BUFFER_WRITE_NV,                                   // Command buffer write operation
-#endif
     THSVS_ACCESS_VERTEX_SHADER_WRITE,                                       // Written as any resource in a vertex shader
     THSVS_ACCESS_TESSELLATION_CONTROL_SHADER_WRITE,                         // Written as any resource in a tessellation control shader
     THSVS_ACCESS_TESSELLATION_EVALUATION_SHADER_WRITE,                      // Written as any resource in a tessellation evaluation shader
@@ -556,15 +552,9 @@ const ThsvsVkAccessInfo ThsvsAccessMap[THSVS_NUM_ACCESS_TYPES] = {
 
 // Read Access
     // THSVS_ACCESS_COMMAND_BUFFER_READ_NV
-#if defined(VK_NV_device_generated_commands)
     {   VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV,
         VK_ACCESS_COMMAND_PREPROCESS_READ_BIT_NV,
         VK_IMAGE_LAYOUT_UNDEFINED},
-#elif defined(VK_NVX_device_generated_commands)
-    {   VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NVX,
-        VK_ACCESS_COMMAND_PREPROCESS_READ_BIT_NVX,
-        VK_IMAGE_LAYOUT_UNDEFINED},
-#endif
     // THSVS_ACCESS_INDIRECT_BUFFER
     {   VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT,
         VK_ACCESS_INDIRECT_COMMAND_READ_BIT,
@@ -764,15 +754,9 @@ const ThsvsVkAccessInfo ThsvsAccessMap[THSVS_NUM_ACCESS_TYPES] = {
 
 // Write access
     // THSVS_ACCESS_COMMAND_BUFFER_WRITE_NV
-#if defined(VK_NV_device_generated_commands)
     {   VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV,
         VK_ACCESS_COMMAND_PREPROCESS_WRITE_BIT_NV,
         VK_IMAGE_LAYOUT_UNDEFINED},
-#elif defined(VK_NVX_device_generated_commands)
-    { VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NVX,
-        VK_ACCESS_COMMAND_PREPROCESS_WRITE_BIT_NVX,
-        VK_IMAGE_LAYOUT_UNDEFINED },
-#endif
     // THSVS_ACCESS_VERTEX_SHADER_WRITE
     {   VK_PIPELINE_STAGE_VERTEX_SHADER_BIT,
         VK_ACCESS_SHADER_WRITE_BIT,

--- a/thsvs_simpler_vulkan_synchronization.h
+++ b/thsvs_simpler_vulkan_synchronization.h
@@ -182,9 +182,10 @@ typedef enum ThsvsAccessType {
     THSVS_ACCESS_NONE,                                                      // No access. Useful primarily for initialization
 
 // Read access
-    // Requires VK_NVX_device_generated_commands to be enabled
-    THSVS_ACCESS_COMMAND_BUFFER_READ_NVX,                                   // Command buffer read operation as defined by NVX_device_generated_commands
-
+#if defined(VK_NV_device_generated_commands) || defined(VK_NVX_device_generated_commands)
+    // Requires VK_NV_device_generated_commands to be enabled
+    THSVS_ACCESS_COMMAND_BUFFER_READ_NV,                                    // Command buffer read operation as defined by NV_device_generated_commands
+#endif
     THSVS_ACCESS_INDIRECT_BUFFER,                                           // Read as an indirect buffer for drawing or dispatch
     THSVS_ACCESS_INDEX_BUFFER,                                              // Read as an index buffer for drawing
     THSVS_ACCESS_VERTEX_BUFFER,                                             // Read as a vertex buffer for drawing
@@ -241,9 +242,10 @@ typedef enum ThsvsAccessType {
     THSVS_END_OF_READ_ACCESS,
 
 // Write access
-    // Requires VK_NVX_device_generated_commands to be enabled
-    THSVS_ACCESS_COMMAND_BUFFER_WRITE_NVX,                                  // Command buffer write operation
-
+#if defined(VK_NV_device_generated_commands) || defined(VK_NVX_device_generated_commands)
+    // Requires VK_NV_device_generated_commands to be enabled
+    THSVS_ACCESS_COMMAND_BUFFER_WRITE_NV,                                   // Command buffer write operation
+#endif
     THSVS_ACCESS_VERTEX_SHADER_WRITE,                                       // Written as any resource in a vertex shader
     THSVS_ACCESS_TESSELLATION_CONTROL_SHADER_WRITE,                         // Written as any resource in a tessellation control shader
     THSVS_ACCESS_TESSELLATION_EVALUATION_SHADER_WRITE,                      // Written as any resource in a tessellation evaluation shader
@@ -553,10 +555,16 @@ const ThsvsVkAccessInfo ThsvsAccessMap[THSVS_NUM_ACCESS_TYPES] = {
         VK_IMAGE_LAYOUT_UNDEFINED},
 
 // Read Access
-    // THSVS_ACCESS_COMMAND_BUFFER_READ_NVX
-    {   VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX,
-        VK_ACCESS_COMMAND_PROCESS_READ_BIT_NVX,
+    // THSVS_ACCESS_COMMAND_BUFFER_READ_NV
+#if defined(VK_NV_device_generated_commands)
+    {   VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV,
+        VK_ACCESS_COMMAND_PREPROCESS_READ_BIT_NV,
         VK_IMAGE_LAYOUT_UNDEFINED},
+#elif defined(VK_NVX_device_generated_commands)
+    {   VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NVX,
+        VK_ACCESS_COMMAND_PREPROCESS_READ_BIT_NVX,
+        VK_IMAGE_LAYOUT_UNDEFINED},
+#endif
     // THSVS_ACCESS_INDIRECT_BUFFER
     {   VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT,
         VK_ACCESS_INDIRECT_COMMAND_READ_BIT,
@@ -755,11 +763,16 @@ const ThsvsVkAccessInfo ThsvsAccessMap[THSVS_NUM_ACCESS_TYPES] = {
         VK_IMAGE_LAYOUT_UNDEFINED},
 
 // Write access
-    // THSVS_ACCESS_COMMAND_BUFFER_WRITE_NVX
-    {   VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX,
-        VK_ACCESS_COMMAND_PROCESS_WRITE_BIT_NVX,
+    // THSVS_ACCESS_COMMAND_BUFFER_WRITE_NV
+#if defined(VK_NV_device_generated_commands)
+    {   VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV,
+        VK_ACCESS_COMMAND_PREPROCESS_WRITE_BIT_NV,
         VK_IMAGE_LAYOUT_UNDEFINED},
-
+#elif defined(VK_NVX_device_generated_commands)
+    { VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NVX,
+        VK_ACCESS_COMMAND_PREPROCESS_WRITE_BIT_NVX,
+        VK_IMAGE_LAYOUT_UNDEFINED },
+#endif
     // THSVS_ACCESS_VERTEX_SHADER_WRITE
     {   VK_PIPELINE_STAGE_VERTEX_SHADER_BIT,
         VK_ACCESS_SHADER_WRITE_BIT,


### PR DESCRIPTION
Fixes #12 